### PR TITLE
Adding new IPs to whitelist and removing special character

### DIFF
--- a/tf-environment/key_vault.tf
+++ b/tf-environment/key_vault.tf
@@ -54,7 +54,7 @@ resource "azurerm_key_vault_access_policy" "adf_access_to_key_vault" {
 resource "random_password" "sql_server_admin_password" {
   length           = 32
   special          = true
-  override_special = "!#$&=+"
+  override_special = "!#$&="
 }
 
 resource "azurerm_key_vault_secret" "subscription_id" {

--- a/tf-environment/sql_server.tf
+++ b/tf-environment/sql_server.tf
@@ -26,6 +26,13 @@ resource "azurerm_mssql_firewall_rule" "mssql_firewall_rule_allow_my_ip" {
   end_ip_address   = var.my_ip_range[1]
 }
 
+resource "azurerm_mssql_firewall_rule" "mssql_firewall_rule_allow_my_ip_2" {
+  name             = "AllowMyIpRange"
+  server_id        = azurerm_mssql_server.demo_sql_server.id
+  start_ip_address = var.my_ip_range[2]
+  end_ip_address   = var.my_ip_range[3]
+}
+
 /* 
   Permitindo que recursos da própria Azure também acessem 
   o SQL Server - Isto é importante pois faremos a escrita dos dados 


### PR DESCRIPTION
Changes:
- Adding 2 new IPs to the IP range to be whitelist on SQL Server
- Removing the `+` character from the list of allowed special characters