### PR TITLE
Feat/New DLT demo & Cluster Data Access Policies

### DIFF
--- a/Delta_Live_Tables/DLT_Pipeline.py
+++ b/Delta_Live_Tables/DLT_Pipeline.py
@@ -1,0 +1,205 @@
+# Databricks notebook source
+import dlt
+import pyspark.sql.functions as F
+
+# COMMAND ----------
+
+varSubscriptionId = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "subscription-id")
+varTenantId = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "tenant-id")
+varResourceGroupName = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "resource-group-name")
+varStorageAccountName = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "storage-account-name")     # Storage acccount name
+varStorageAccountAccessKey = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "storage-account-key") # Storage access key
+varApplicationId = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "azure-ad-application-id")
+varAuthenticationKey = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "azure-id-authentication-key")
+varFileSystemName = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "storage-account-general-purpose-container") # ADLS container name
+varEventHubNameSpace = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "eventhub-namespace") # EventHubNamespace
+varEventHubName = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "storage-account-general-purpose-container") # ADLS container name
+
+synapse_storage_container = dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "storage-account-synapse-container") # ADLS container name for Synapse Integration
+
+varRootBucketPath = f"abfss://{varFileSystemName}@{varStorageAccountName}.dfs.core.windows.net"
+varLandingZonePath = f"abfss://{varFileSystemName}@{varStorageAccountName}.dfs.core.windows.net/landing"
+
+adf_landing_zone = varLandingZonePath
+delta_tables_root_path = f"{varRootBucketPath}/delta_tables"
+checkpoints_root_path = f"{varRootBucketPath}/checkPoints"
+schema_checkpoints_root_path = f"{varRootBucketPath}/schemaCheckPoints"
+
+spark.conf.set("fs.azure.account.auth.type", "OAuth")
+spark.conf.set("fs.azure.account.oauth.provider.type",  "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider")
+spark.conf.set("fs.azure.account.oauth2.client.id", varApplicationId)
+spark.conf.set("fs.azure.account.oauth2.client.secret", varAuthenticationKey)
+spark.conf.set("fs.azure.account.oauth2.client.endpoint", f"https://login.microsoftonline.com/{varTenantId}/oauth2/token")
+spark.conf.set(f"fs.azure.account.key.{varStorageAccountName}.dfs.core.windows.net", varStorageAccountAccessKey)
+
+# COMMAND ----------
+
+# Auto Loader configurations
+cloudfile = {
+#   Authentication Options for access using an Azure AD App
+  "cloudFiles.subscriptionId": varSubscriptionId,
+  "cloudFiles.tenantId": varTenantId,
+  "cloudFiles.clientId": varApplicationId,
+  "cloudFiles.clientSecret": varAuthenticationKey,
+  "cloudFiles.resourceGroup": varResourceGroupName,
+  "cloudFiles.format": "parquet",
+  "cloudFiles.useNotifications": "true"
+}
+
+# COMMAND ----------
+
+@dlt.table
+def silver_maintenance_data():
+    return (
+        spark.readStream.format("cloudFiles")
+            .options(**cloudfile)
+            .option("cloudFiles.schemaLocation", f"{schema_checkpoints_root_path}/turbine_status")
+            .load(f"{adf_landing_zone}/status_data")
+    )
+
+# COMMAND ----------
+
+@dlt.table
+def silver_poweroutput_data():
+    return (
+        spark.readStream.format("cloudFiles")
+            .options(**cloudfile)
+            .option("cloudFiles.schemaLocation", f"{schema_checkpoints_root_path}/turbine_sensor_data")
+            .load(f"{adf_landing_zone}/power_output")
+    )
+
+# COMMAND ----------
+
+@dlt.table
+def bronze_sensor_data():
+    readConnectionString=dbutils.secrets.get(scope = "keyvault-managed-secret-scope", key = "eventhub-iot-endpoint")
+    eh_sasl = f'kafkashaded.org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="{readConnectionString}";'
+    kafka_options = {
+         "kafka.bootstrap.servers": f"{varEventHubNameSpace}.servicebus.windows.net:9093",
+         "kafka.sasl.mechanism": "PLAIN",
+         "kafka.security.protocol": "SASL_SSL",
+         "kafka.request.timeout.ms": "60000",
+         "kafka.session.timeout.ms": "30000",
+         "startingOffsets": "earliest",
+         "kafka.sasl.jaas.config": eh_sasl,
+         "subscribe": f"{varEventHubName}",
+    }
+    # Schema of incoming data from IoT hub
+    schema = "timestamp timestamp, deviceId string, temperature double, humidity double, windspeed double, winddirection string, rpm double, angle double"
+    iot_stream = (
+                spark.readStream.format("kafka")
+                  .options(**kafka_options)
+                  .load()
+                  .withColumn('reading', F.from_json(F.col('value').cast('string'), schema))        # Extract the "body" payload from the messages
+                  .select('reading.*', F.to_date('reading.timestamp').alias('date'))                # Create a "date" field for partitioning
+    )
+    return iot_stream
+
+# COMMAND ----------
+
+@dlt.table
+def silver_turbine_data():
+    return dlt.read_stream("bronze_sensor_data").where("temperature IS NULL").select("date", "timestamp", "deviceId", "rpm", "angle")
+
+# COMMAND ----------
+
+@dlt.table
+def silver_weather_data():
+    return dlt.read_stream("bronze_sensor_data").where("temperature IS NOT NULL").select("date", "deviceid", "timestamp", "temperature", "humidity", "windspeed", "winddirection")
+
+# COMMAND ----------
+
+@dlt.table
+def silver_agg_weather_data():
+    stream_data = (
+                    dlt.read_stream("silver_weather_data")
+                    .withWatermark("timestamp", "1 hour")
+                    .groupby("date"
+                             , F.date_trunc("hour", F.col("timestamp")).alias("window") # F.window(dlt.read_stream("silver_weather_data").timestamp, "1 hour")
+                             , "deviceId"
+                            )
+                    .agg(
+                            F.avg("temperature").alias("temperature"), 
+                            F.avg("humidity").alias("humidity"),
+                            F.avg("windspeed").alias("windspeed"),
+                            F.last("winddirection").alias("winddirection")
+#                             F.date_trunc("hour", F.min("timestamp")).alias("window")
+                        )
+                    .withColumn("watermark", F.current_timestamp())
+    )
+    return stream_data
+        
+# target = "silver_agg_weather_data"
+# source = f"{target}_append"
+
+# dlt.create_streaming_live_table(target)
+
+# dlt.apply_changes(
+#   target = target,
+#   source = source,
+#   keys = ["date", "window", "deviceid"],
+#   sequence_by = F.col("watermark"),
+#   stored_as_scd_type = 1
+# )
+
+# COMMAND ----------
+
+@dlt.table
+def silver_agg_turbine_data():
+    stream_data = (
+                    dlt.read_stream("silver_turbine_data")
+                    .withWatermark("timestamp", "1 hour")
+                    .groupby("date"
+                             , F.date_trunc("hour", F.col("timestamp")).alias("window")
+                             , "deviceId"
+                            )
+                    .agg(
+                            F.avg("rpm").alias("rpm"), 
+                            F.avg("angle").alias("angle")
+#                             F.date_trunc("hour", F.min("timestamp")).alias("window")
+                    )
+                    .withColumn("watermark", F.current_timestamp())
+    )
+    return stream_data
+        
+# target = "silver_agg_turbine_data"
+# source = f"{target}_append"
+
+# dlt.create_streaming_live_table(target)
+
+# dlt.apply_changes(
+#   target = target,
+#   source = source,
+#   keys = ["date", "window", "deviceid"],
+#   sequence_by = F.col("watermark"),
+#   stored_as_scd_type = 1
+# )
+
+# COMMAND ----------
+
+@dlt.table
+def gold_turbine_data():
+    turbine_sensor = dlt.read_stream("silver_agg_turbine_data").withColumn("hour", F.date_format(F.col("window"), 'H:mm'))
+    maintenance = dlt.read_stream("silver_maintenance_data")
+    power_output = dlt.read_stream("silver_poweroutput_data")
+    weather = dlt.read_stream("silver_agg_weather_data")
+    final_data = (turbine_sensor.select("date", "window", "deviceId", "rpm", "angle")
+                  .join(weather.select("date", "window", "temperature", "humidity", "windspeed", "winddirection"), ["date", "window"])
+                  .join(maintenance.select("date", "deviceId", "maintenance"), ["date", "deviceId"])
+                  .join(power_output.select("date", "window", "deviceId", "power"), ["date", "window", "deviceId"])
+                  .withColumn("watermark", F.current_timestamp())
+                 )
+    return final_data
+    
+# target = "gold_turbine_data"
+# source = f"{target}_vw"
+
+# dlt.create_streaming_live_table(target)
+
+# dlt.apply_changes(
+#   target = target,
+#   source = source,
+#   keys = ["date", "window", "deviceid"],
+#   sequence_by = F.col("watermark"),
+#   stored_as_scd_type = 1
+# )

--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@
 ## How to run this demo on your own:
 ---
 
-1. Install Azure-cli
-2. Run 'az config set extension.use_dynamic_install=yes_without_prompt' to allow installing extensions without prompt.
-3. Install terraform cli
-4. Run az login to authenticate (make sure you are on the right tenant)
-5. Run a terraform plan on the folder tf-environment, make sure it works properly (no authentication errors)
-6. Run a Terraform Apply, the first apply will not work for the IOT device, but it should work perfectly on the second one
-7. After the second apply, the demo should be ready to roll
-8. Get the IoT Connection string of your device and replace it on the code `scripts/iot_simulator_code/iot_simulator.js`
-9. Go to [Azure's IoT simulator and add the code](https://azure-samples.github.io/raspberry-pi-web-simulator/)
+1. Install Azure-cli - [How to install azure-cli](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+2. Run `az config set extension.use_dynamic_install=yes_without_prompt` to allow installing extensions without prompt.
+3. Install terraform cli - [How to install terraform-cli](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+4. Run `az login` to authenticate (make sure you are on the right tenant)
+5. Go to the `tf-environment` folder (on unix based systems, the command is: `cd tf-environment`)
+6. Run a `terraform init` to initialize terraform and install the required providers
+7. Run a `terraform plan` on the folder tf-environment, make sure it works properly (i.e.: no authentication errors)
+8. Run a `terraform apply`, the first apply will probably not work for the IOT device as it will have to install the library, but it should work perfectly on the second one
+9. After the second `terraform apply`, the demo should be ready to roll
+10. Go to [Azure's IoT simulator](https://azure-samples.github.io/raspberry-pi-web-simulator/) and add the code in `scripts/iot_simulator_code/iot_simulator.js`
+11. Get the IoT Connection string of your device and replace it on the code that you just pasted on the simulator on the previous step
+12. Access your DataFactory to get the data out of the SQL Server by running the pipeline called `historical_pipeline` once
+13. After going through the previous step, you are now able to run the DLT demo or the separate notebooks for a classic demo. 
+14. When you're done playing, DON'T FORGET to destroy your resources by running a `terraform destroy`

--- a/tf-environment/databricks_workspace.tf
+++ b/tf-environment/databricks_workspace.tf
@@ -174,18 +174,19 @@ resource "databricks_cluster_policy" "default_data_access_policy" {
 }
 
 data "databricks_notebook" "dlt_demo_notebook" {
-  path = "/${data.databricks_current_user.me.home}/DLT_Demo/DLT_Pipeline"
+  path   = "/${data.databricks_current_user.me.home}/DLT_Demo/DLT_Pipeline"
   format = "SOURCE"
 }
 
 resource "databricks_pipeline" "demo_dlt_pipeline" {
-  name       = "Demo_DLT_Pipeline"
-  storage    = "abfss://${resource.azurerm_storage_container.demo_general_purpose_container.name}@${resource.azurerm_storage_account.demo_storage_account.name}.dfs.core.windows.net/dlt"
-  continuous = true
-  channel    = "preview"
-  target     = "dlt_demo"
-  photon     = false
-  edition    = "advanced"
+  name        = "Demo_DLT_Pipeline"
+  storage     = "abfss://${resource.azurerm_storage_container.demo_general_purpose_container.name}@${resource.azurerm_storage_account.demo_storage_account.name}.dfs.core.windows.net/dlt"
+  target      = "dlt_demo"
+  channel     = "preview"
+  edition     = "advanced"
+  photon      = false
+  continuous  = false
+  development = true
   cluster {
     label     = "default"
     policy_id = resource.databricks_cluster_policy.default_data_access_policy.id

--- a/tf-environment/databricks_workspace.tf
+++ b/tf-environment/databricks_workspace.tf
@@ -174,7 +174,7 @@ resource "databricks_cluster_policy" "default_data_access_policy" {
 }
 
 data "databricks_notebook" "dlt_demo_notebook" {
-  path   = "/${data.databricks_current_user.me.home}/DLT_Demo/DLT_Pipeline"
+  path   = "${data.databricks_current_user.me.home}/DLT_Demo/DLT_Pipeline"
   format = "SOURCE"
 }
 

--- a/tf-environment/event_and_iot_hub.tf
+++ b/tf-environment/event_and_iot_hub.tf
@@ -3,7 +3,7 @@ resource "azurerm_eventhub_namespace" "demo_eventhub_namespace" {
   name                = local.demo_eventhub_namespace
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
-  sku                 = "Basic"
+  sku                 = "Standard"
   tags                = local.tags
 }
 

--- a/tf-environment/key_vault.tf
+++ b/tf-environment/key_vault.tf
@@ -220,7 +220,17 @@ resource "azurerm_key_vault_secret" "sql_server_database" {
 
 resource "azurerm_key_vault_secret" "event_hub_name" {
   name         = "eventhub-name"
-  value        = local.demo_eventhub_name
+  value        = resource.azurerm_eventhub.demo_eventhub.name
+  key_vault_id = azurerm_key_vault.demo_key_vault.id
+  depends_on = [
+    resource.azurerm_key_vault_access_policy.user_access_to_key_vault,
+    resource.azurerm_key_vault_access_policy.adf_access_to_key_vault,
+  ]
+}
+
+resource "azurerm_key_vault_secret" "event_hub_namespace" {
+  name         = "eventhub-namespace"
+  value        = resource.azurerm_eventhub_namespace.demo_eventhub_namespace.name
   key_vault_id = azurerm_key_vault.demo_key_vault.id
   depends_on = [
     resource.azurerm_key_vault_access_policy.user_access_to_key_vault,

--- a/tf-environment/storage_account.tf
+++ b/tf-environment/storage_account.tf
@@ -62,8 +62,8 @@ data "azurerm_storage_account_sas" "sas_for_storage_account" {
     file  = true
   }
 
-  start  = "${resource.time_static.sas_token_start_date.rfc3339}"
-  expiry = "${resource.time_offset.sas_token_expiration_date.rfc3339}"
+  start  = resource.time_static.sas_token_start_date.rfc3339
+  expiry = resource.time_offset.sas_token_expiration_date.rfc3339
   permissions {
     read    = true
     write   = true


### PR DESCRIPTION
Changes:
- Added cluster data access policies to enable data viz on cluster
- Added a functional DLT pipeline to obtain the same results as the previous notebook based demo
- Fixed SKU on Eventhub to allow for Kafka reads
- Improved keyvault governance by taking key values from resource names instead of variables
- Adjusted cluster autotermination to 120 minutes instead of 20 to help with development (we might want to reverse that afterwards)