### PR TITLE
Removing SQL from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ignoring our SQL Examples on our files for repo statistics purposes
+
+*.sql linguist-detectable=false
+*.sql linguist-language=sql


### PR DESCRIPTION
Changes:
- Added `.gitattributes` file to ignore sql files